### PR TITLE
Add option to run .tst without cmp

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -59,6 +59,12 @@ yargs(hideBin(process.argv))
           type: "string",
           describe:
             "When set, look for the java IDE jars in this path and compare both runs.",
+        })
+        .option("cmp", {
+          type: "boolean",
+          default: true,
+          describe:
+            "Compare output against .cmp file (use --no-cmp to disable).",
         }),
     (argv) => {
       console.log("nand2tetris command run", argv);
@@ -67,7 +73,11 @@ yargs(hideBin(process.argv))
         case "":
         case ".tst":
           console.log("tst");
-          testRunner(dirname(resolve(argv.file ?? process.cwd())), name);
+          testRunner(
+            dirname(resolve(argv.file ?? process.cwd())),
+            name,
+            argv.cmp,
+          );
           break;
         case ".hdl":
           console.log("hdl");


### PR DESCRIPTION
## Summary
- add `--cmp/--no-cmp` flag to `nand2tetris run`
- optionally skip comparing output in `testrunner`

## Testing
- `npx prettier --write cli/src/index.ts cli/src/testrunner.ts`
- `npm run build -w cli` *(fails: tsc not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ad1065b24832b91c1314ded91a971