### PR TITLE
Handle stdin tests for HDL run

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -69,8 +69,7 @@ yargs(hideBin(process.argv))
           console.log("tst");
           testRunner(dirname(resolve(argv.file ?? process.cwd())), name);
           break;
-        case ".hdl":
-          console.log("hdl");
+        case ".hdl": {
           const tst = fsCore.readFileSync(0, "utf8");
           testRunnerFromSource(
             dirname(resolve(argv.file ?? process.cwd())),
@@ -78,6 +77,7 @@ yargs(hideBin(process.argv))
             tst,
           );
           break;
+        }
         default:
           console.log("unknown", ext);
           break;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -3,7 +3,7 @@ import path, { dirname, parse, resolve } from "path";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { main } from "./grading.js";
-import { testRunner } from "./testrunner.js";
+import { testRunner, testRunnerFromSource } from "./testrunner.js";
 import { NodeFileSystemAdapter } from "@davidsouther/jiffies/lib/esm/fs_node.js";
 import { FileSystem } from "@davidsouther/jiffies/lib/esm/fs.js";
 import * as fsCore from "fs";
@@ -71,6 +71,12 @@ yargs(hideBin(process.argv))
           break;
         case ".hdl":
           console.log("hdl");
+          const tst = fsCore.readFileSync(0, "utf8");
+          testRunnerFromSource(
+            dirname(resolve(argv.file ?? process.cwd())),
+            name,
+            tst,
+          );
           break;
         default:
           console.log("unknown", ext);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -61,7 +61,6 @@ yargs(hideBin(process.argv))
             "When set, look for the java IDE jars in this path and compare both runs.",
         }),
     (argv) => {
-      console.log("nand2tetris command run", argv);
       const { name, ext } = parse(argv.file ?? "");
       switch (ext) {
         case "":

--- a/cli/src/testrunner.ts
+++ b/cli/src/testrunner.ts
@@ -34,13 +34,8 @@ async function loadAssignmentFromSource(
   file: Assignment,
   tst: string,
 ) {
-  const assignment = Assignments[file.name as keyof typeof Assignments];
   const hdl = await fs.readFile(`${file.name}.hdl`);
-  const cmp = await fs
-    .readFile(`${file.name}.cmp`)
-    .catch(
-      () => assignment[`${file.name}.cmp` as keyof typeof assignment] as string,
-    );
+  const cmp = await fs.readFile(`${file.name}.cmp`).catch(() => "" as string);
   return { ...file, hdl, tst, cmp };
 }
 

--- a/cli/src/testrunner.ts
+++ b/cli/src/testrunner.ts
@@ -27,12 +27,46 @@ async function loadAssignment(fs: FileSystem, file: Assignment) {
 }
 
 /**
+ * Load an assignment using a provided tst string instead of reading from disk.
+ */
+async function loadAssignmentFromSource(
+  fs: FileSystem,
+  file: Assignment,
+  tst: string,
+) {
+  const assignment = Assignments[file.name as keyof typeof Assignments];
+  const hdl = await fs.readFile(`${file.name}.hdl`);
+  const cmp = await fs
+    .readFile(`${file.name}.cmp`)
+    .catch(
+      () => assignment[`${file.name}.cmp` as keyof typeof assignment] as string,
+    );
+  return { ...file, hdl, tst, cmp };
+}
+
+/**
  * Run a nand2tetris.tst file.
  */
 export async function testRunner(dir: string, file: string) {
   const fs = new FileSystem(new NodeFileSystemAdapter());
   fs.cd(dir);
   const assignment = await loadAssignment(fs, parse(file));
+  const tryRun = runner(fs);
+  const run = await tryRun(assignment);
+  console.log(run);
+}
+
+/**
+ * Run a chip HDL using a tst script passed as a string via stdin.
+ */
+export async function testRunnerFromSource(
+  dir: string,
+  file: string,
+  tst: string,
+) {
+  const fs = new FileSystem(new NodeFileSystemAdapter());
+  fs.cd(dir);
+  const assignment = await loadAssignmentFromSource(fs, parse(file), tst);
   const tryRun = runner(fs);
   const run = await tryRun(assignment);
   console.log(run);


### PR DESCRIPTION
## Summary
- extend CLI run command to read tests from stdin when running an `.hdl`
- add helpers in testrunner for running with a provided test script

## Testing
- `npm run build -w cli` *(fails: Cannot find module '@nand2tetris/projects/base.js'...)*
- `npm test -w cli` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_b_683af1c8f728832bbabc6dfbfedd94a8